### PR TITLE
Allow to Skip Mark As Completed

### DIFF
--- a/src/Contracts/JobRepository.php
+++ b/src/Contracts/JobRepository.php
@@ -164,6 +164,13 @@ interface JobRepository
     public function completed(JobPayload $payload, $failed = false);
 
     /**
+     * Remove a job from pending
+     * @param JobPayload $payload
+     * @return mixed
+     */
+    public function removeJobFromPending(JobPayload $payload);
+
+    /**
      * Delete the given monitored jobs by IDs.
      *
      * @param  array  $ids

--- a/src/JobPayload.php
+++ b/src/JobPayload.php
@@ -90,6 +90,7 @@ class JobPayload implements ArrayAccess
             'type' => $this->determineType($job),
             'tags' => $this->determineTags($job),
             'pushedAt' => str_replace(',', '.', microtime(true)),
+            'shouldSkipMarkAsCompleted' => method_exists($job, 'shouldSkipMarkAsCompleted') ? $job->shouldSkipMarkAsCompleted() : false,
         ]);
     }
 

--- a/src/Jobs/SqsJob.php
+++ b/src/Jobs/SqsJob.php
@@ -33,4 +33,13 @@ class SqsJob extends \Illuminate\Queue\Jobs\SqsJob
         $payloadBody['attempts'] = $this->attempts();
         return json_encode($payloadBody);
     }
+
+    /**
+     * Return whether we should shouldSkipMarkAsCompleted in horizon
+     * @return false
+     */
+    public function shouldSkipMarkAsCompleted()
+    {
+        return isset($this->payload()['shouldSkipMarkAsCompleted']) ?? false;
+    }
 }

--- a/src/Listeners/MarkJobAsComplete.php
+++ b/src/Listeners/MarkJobAsComplete.php
@@ -44,7 +44,7 @@ class MarkJobAsComplete
     public function handle(JobDeleted $event)
     {
         # If the job want to skip mark as completed, then just remove from pending_jobs
-        if (method_exists($event->job, 'shouldSkipMarkAsCompleted') && $event->job->shouldSkipMarkAsCompleted()) {
+        if (!$event->job->hasFailed() && method_exists($event->job, 'shouldSkipMarkAsCompleted') && $event->job->shouldSkipMarkAsCompleted()) {
             $this->jobs->removeJobFromPending($event->payload);
             return;
         }

--- a/src/Listeners/MarkJobAsComplete.php
+++ b/src/Listeners/MarkJobAsComplete.php
@@ -43,6 +43,12 @@ class MarkJobAsComplete
      */
     public function handle(JobDeleted $event)
     {
+        # If the job want to skip mark as completed, then just remove from pending_jobs
+        if (method_exists($event->job, 'shouldSkipMarkAsCompleted') && $event->job->shouldSkipMarkAsCompleted()) {
+            $this->jobs->removeJobFromPending($event->payload);
+            return;
+        }
+
         $this->jobs->completed($event->payload, $event->job->hasFailed());
 
         if (! $event->job->hasFailed() && count($this->tags->monitored($event->payload->tags())) > 0) {

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -477,6 +477,10 @@ class RedisJobRepository implements JobRepository
      */
     public function removeJobFromPending(JobPayload $payload)
     {
+        if ($payload->isRetry()) {
+            $this->updateRetryInformationOnParent($payload, false);
+        }
+
         $this->connection()->pipeline(function ($pipe) use ($payload) {
             $this->removeJobReference($pipe, 'pending_jobs', $payload);
         });

--- a/src/Repositories/RedisJobRepository.php
+++ b/src/Repositories/RedisJobRepository.php
@@ -471,6 +471,18 @@ class RedisJobRepository implements JobRepository
     }
 
     /**
+     * Remove a job payload from pending_jobs
+     * @param JobPayload $payload
+     * @return void
+     */
+    public function removeJobFromPending(JobPayload $payload)
+    {
+        $this->connection()->pipeline(function ($pipe) use ($payload) {
+            $this->removeJobReference($pipe, 'pending_jobs', $payload);
+        });
+    }
+
+    /**
      * Update the retry status of a job's parent.
      *
      * @param  \Laravel\Horizon\JobPayload  $payload


### PR DESCRIPTION
- Allow to skip completed_jobs being saved to Redis by specifing `shouldSkipMarkAsCompleted` in Job